### PR TITLE
Return `Key::Tab` instead of `\t` on windows

### DIFF
--- a/src/windows_term/mod.rs
+++ b/src/windows_term/mod.rs
@@ -390,6 +390,8 @@ pub fn read_single_key() -> io::Result<Key> {
                 // a special keycode for `Enter`, while ReadConsoleInputW() prefers to use '\r'.
                 if c == '\r' {
                     Ok(Key::Enter)
+                } else if c == '\t' {
+                    Ok(Key::Tab)
                 } else if c == '\x08' {
                     Ok(Key::Backspace)
                 } else if c == '\x1B' {


### PR DESCRIPTION
On windows this crate retuns `Key::Char('\t') so code like https://github.com/console-rs/dialoguer/blob/master/src/prompts/input.rs#L474 doesn't work as intended